### PR TITLE
Make it possible to continue after evaluation

### DIFF
--- a/calc.go
+++ b/calc.go
@@ -54,8 +54,6 @@ func (c *calc) evaluate() {
 		log.Println("Error in calculation", err)
 		c.display("error")
 	}
-
-	c.equation = ""
 }
 
 func (c *calc) addButton(text string, action func()) *widget.Button {

--- a/calc_test.go
+++ b/calc_test.go
@@ -20,6 +20,75 @@ func TestAdd(t *testing.T) {
 	assert.Equal(t, "2", calc.output.Text)
 }
 
+func TestSubtract(t *testing.T) {
+	calc := newCalculator()
+	calc.loadUI(test.NewApp())
+
+	test.Tap(calc.buttons["2"])
+	test.Tap(calc.buttons["-"])
+	test.Tap(calc.buttons["1"])
+	test.Tap(calc.buttons["="])
+
+	assert.Equal(t, "1", calc.output.Text)
+}
+
+func TestDivide(t *testing.T) {
+	calc := newCalculator()
+	calc.loadUI(test.NewApp())
+
+	test.Tap(calc.buttons["3"])
+	test.Tap(calc.buttons["/"])
+	test.Tap(calc.buttons["2"])
+	test.Tap(calc.buttons["="])
+
+	assert.Equal(t, "1.5", calc.output.Text)
+}
+
+func TestMultiply(t *testing.T) {
+	calc := newCalculator()
+	calc.loadUI(test.NewApp())
+
+	test.Tap(calc.buttons["5"])
+	test.Tap(calc.buttons["*"])
+	test.Tap(calc.buttons["2"])
+	test.Tap(calc.buttons["="])
+
+	assert.Equal(t, "10", calc.output.Text)
+}
+
+func TestParenthesis(t *testing.T) {
+	calc := newCalculator()
+	calc.loadUI(test.NewApp())
+
+	test.Tap(calc.buttons["2"])
+	test.Tap(calc.buttons["*"])
+	test.Tap(calc.buttons["("])
+	test.Tap(calc.buttons["3"])
+	test.Tap(calc.buttons["+"])
+	test.Tap(calc.buttons["4"])
+	test.Tap(calc.buttons[")"])
+	test.Tap(calc.buttons["="])
+
+	assert.Equal(t, "14", calc.output.Text)
+}
+
+func TestDot(t *testing.T) {
+	calc := newCalculator()
+	calc.loadUI(test.NewApp())
+
+	test.Tap(calc.buttons["2"])
+	test.Tap(calc.buttons["."])
+	test.Tap(calc.buttons["2"])
+	test.Tap(calc.buttons["+"])
+	test.Tap(calc.buttons["7"])
+	test.Tap(calc.buttons["."])
+	test.Tap(calc.buttons["8"])
+
+	test.Tap(calc.buttons["="])
+
+	assert.Equal(t, "10", calc.output.Text)
+}
+
 func TestClear(t *testing.T) {
 	calc := newCalculator()
 	calc.loadUI(test.NewApp())

--- a/calc_test.go
+++ b/calc_test.go
@@ -83,7 +83,6 @@ func TestDot(t *testing.T) {
 	test.Tap(calc.buttons["7"])
 	test.Tap(calc.buttons["."])
 	test.Tap(calc.buttons["8"])
-
 	test.Tap(calc.buttons["="])
 
 	assert.Equal(t, "10", calc.output.Text)
@@ -98,6 +97,21 @@ func TestClear(t *testing.T) {
 	test.Tap(calc.buttons["C"])
 
 	assert.Equal(t, "", calc.output.Text)
+}
+
+func TestContinueAfterResult(t *testing.T) {
+	calc := newCalculator()
+	calc.loadUI(test.NewApp())
+
+	test.Tap(calc.buttons["6"])
+	test.Tap(calc.buttons["+"])
+	test.Tap(calc.buttons["4"])
+	test.Tap(calc.buttons["="])
+	test.Tap(calc.buttons["-"])
+	test.Tap(calc.buttons["2"])
+	test.Tap(calc.buttons["="])
+
+	assert.Equal(t, "8", calc.output.Text)
 }
 
 func TestKeyboard(t *testing.T) {


### PR DESCRIPTION
This removes the code that reset the content after it was evaluated. This makes the calulcator behave more like other calculators in that you can do for example "5 + 5 = 10" and then "10 + 5 = 15" without re-writing the "10" after pressing the equal sign. Clear should use the clear button.

![calculator-improved](https://user-images.githubusercontent.com/25466657/120355753-d8875c80-c303-11eb-95b9-98b80add1214.gif)