### PR TITLE
Add support for copy and paste shortcuts

### DIFF
--- a/calc.go
+++ b/calc.go
@@ -90,19 +90,17 @@ func (c *calc) onTypedKey(ev *fyne.KeyEvent) {
 	}
 }
 
-func (c *calc) onTypedShortcut(shortcut fyne.Shortcut) {
-	if pasted, ok := shortcut.(*fyne.ShortcutPaste); ok {
-		content := pasted.Clipboard.Content()
-		if _, err := strconv.ParseFloat(content, 64); err == nil {
-			c.display(c.equation + content)
-		}
-
+func (c *calc) onPasteShortcut(shortcut fyne.Shortcut) {
+	content := shortcut.(*fyne.ShortcutPaste).Clipboard.Content()
+	if _, err := strconv.ParseFloat(content, 64); err != nil {
 		return
 	}
 
-	if copied, ok := shortcut.(*fyne.ShortcutCopy); ok {
-		copied.Clipboard.SetContent(c.equation)
-	}
+	c.display(c.equation + content)
+}
+
+func (c *calc) onCopyShortcut(shortcut fyne.Shortcut) {
+	shortcut.(*fyne.ShortcutCopy).Clipboard.SetContent(c.equation)
 }
 
 func (c *calc) loadUI(app fyne.App) {
@@ -144,8 +142,8 @@ func (c *calc) loadUI(app fyne.App) {
 
 	c.window.Canvas().SetOnTypedRune(c.onTypedRune)
 	c.window.Canvas().SetOnTypedKey(c.onTypedKey)
-	c.window.Canvas().AddShortcut(&fyne.ShortcutCopy{}, c.onTypedShortcut)
-	c.window.Canvas().AddShortcut(&fyne.ShortcutPaste{}, c.onTypedShortcut)
+	c.window.Canvas().AddShortcut(&fyne.ShortcutCopy{}, c.onCopyShortcut)
+	c.window.Canvas().AddShortcut(&fyne.ShortcutPaste{}, c.onPasteShortcut)
 	c.window.Resize(fyne.NewSize(200, 300))
 	c.window.Show()
 }

--- a/calc.go
+++ b/calc.go
@@ -100,8 +100,8 @@ func (c *calc) onTypedShortcut(shortcut fyne.Shortcut) {
 		return
 	}
 
-	if _, ok := shortcut.(*fyne.ShortcutCopy); ok {
-		fyne.CurrentApp().Driver().AllWindows()[0].Clipboard().SetContent(c.equation)
+	if copied, ok := shortcut.(*fyne.ShortcutCopy); ok {
+		copied.Clipboard.SetContent(c.equation)
 	}
 }
 

--- a/calc.go
+++ b/calc.go
@@ -90,6 +90,21 @@ func (c *calc) onTypedKey(ev *fyne.KeyEvent) {
 	}
 }
 
+func (c *calc) onTypedShortcut(shortcut fyne.Shortcut) {
+	if pasted, ok := shortcut.(*fyne.ShortcutPaste); ok {
+		content := pasted.Clipboard.Content()
+		if _, err := strconv.ParseFloat(content, 64); err == nil {
+			c.display(c.equation + content)
+		}
+
+		return
+	}
+
+	if _, ok := shortcut.(*fyne.ShortcutCopy); ok {
+		fyne.CurrentApp().Driver().AllWindows()[0].Clipboard().SetContent(c.equation)
+	}
+}
+
 func (c *calc) loadUI(app fyne.App) {
 	c.output = &widget.Label{Alignment: fyne.TextAlignTrailing}
 	c.output.TextStyle.Monospace = true
@@ -129,6 +144,8 @@ func (c *calc) loadUI(app fyne.App) {
 
 	c.window.Canvas().SetOnTypedRune(c.onTypedRune)
 	c.window.Canvas().SetOnTypedKey(c.onTypedKey)
+	c.window.Canvas().AddShortcut(&fyne.ShortcutCopy{}, c.onTypedShortcut)
+	c.window.Canvas().AddShortcut(&fyne.ShortcutPaste{}, c.onTypedShortcut)
 	c.window.Resize(fyne.NewSize(200, 300))
 	c.window.Show()
 }

--- a/calc_test.go
+++ b/calc_test.go
@@ -162,16 +162,16 @@ func TestShortcuts(t *testing.T) {
 	clipboard := app.Driver().AllWindows()[0].Clipboard()
 
 	test.TypeOnCanvas(calc.window.Canvas(), "720 + 80")
-	calc.onTypedShortcut(&fyne.ShortcutCopy{Clipboard: clipboard})
+	calc.onCopyShortcut(&fyne.ShortcutCopy{Clipboard: clipboard})
 	assert.Equal(t, clipboard.Content(), calc.output.Text)
 
 	test.TypeOnCanvas(calc.window.Canvas(), "+")
 	clipboard.SetContent("50")
-	calc.onTypedShortcut(&fyne.ShortcutPaste{Clipboard: clipboard})
+	calc.onPasteShortcut(&fyne.ShortcutPaste{Clipboard: clipboard})
 	test.TypeOnCanvas(calc.window.Canvas(), "=")
 	assert.Equal(t, "850", calc.output.Text)
 
 	clipboard.SetContent("not a valid number")
-	calc.onTypedShortcut(&fyne.ShortcutPaste{Clipboard: clipboard})
+	calc.onPasteShortcut(&fyne.ShortcutPaste{Clipboard: clipboard})
 	assert.Equal(t, "850", calc.output.Text)
 }

--- a/calc_test.go
+++ b/calc_test.go
@@ -156,12 +156,13 @@ func TestError(t *testing.T) {
 }
 
 func TestShortcuts(t *testing.T) {
+	app := test.NewApp()
 	calc := newCalculator()
-	calc.loadUI(test.NewApp())
-	clipboard := fyne.CurrentApp().Driver().AllWindows()[0].Clipboard()
+	calc.loadUI(app)
+	clipboard := app.Driver().AllWindows()[0].Clipboard()
 
 	test.TypeOnCanvas(calc.window.Canvas(), "720 + 80")
-	calc.onTypedShortcut(&fyne.ShortcutCopy{})
+	calc.onTypedShortcut(&fyne.ShortcutCopy{Clipboard: clipboard})
 	assert.Equal(t, clipboard.Content(), calc.output.Text)
 
 	test.TypeOnCanvas(calc.window.Canvas(), "+")

--- a/calc_test.go
+++ b/calc_test.go
@@ -154,3 +154,23 @@ func TestError(t *testing.T) {
 	test.TypeOnCanvas(calc.window.Canvas(), "1//1=")
 	assert.Equal(t, "error", calc.output.Text)
 }
+
+func TestShortcuts(t *testing.T) {
+	calc := newCalculator()
+	calc.loadUI(test.NewApp())
+	clipboard := fyne.CurrentApp().Driver().AllWindows()[0].Clipboard()
+
+	test.TypeOnCanvas(calc.window.Canvas(), "720 + 80")
+	calc.onTypedShortcut(&fyne.ShortcutCopy{})
+	assert.Equal(t, clipboard.Content(), calc.output.Text)
+
+	test.TypeOnCanvas(calc.window.Canvas(), "+")
+	clipboard.SetContent("50")
+	calc.onTypedShortcut(&fyne.ShortcutPaste{Clipboard: clipboard})
+	test.TypeOnCanvas(calc.window.Canvas(), "=")
+	assert.Equal(t, "850", calc.output.Text)
+
+	clipboard.SetContent("not a valid number")
+	calc.onTypedShortcut(&fyne.ShortcutPaste{Clipboard: clipboard})
+	assert.Equal(t, "850", calc.output.Text)
+}


### PR DESCRIPTION
This PR adds support for the calculator to paste numbers into the interface and also copy anything that is there (both numbers and expressions). This is a good step towards making the calculator more user friendly.