### PR TITLE
Don't crash on invalid inputs, fixes #16

### DIFF
--- a/calc.go
+++ b/calc.go
@@ -51,12 +51,14 @@ func (c *calc) evaluate() {
 	}
 
 	result, err := expression.Evaluate(nil)
-	value, ok := result.(float64)
 	if err != nil {
 		log.Println("Error in calculation", err)
 		c.display("error")
 		return
-	} else if !ok {
+	}
+
+	value, ok := result.(float64)
+	if !ok {
 		log.Println("Invalid input:", c.output.Text)
 		c.display("error")
 		return

--- a/calc.go
+++ b/calc.go
@@ -5,6 +5,7 @@ package main
 import (
 	"log"
 	"strconv"
+	"strings"
 
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/container"
@@ -39,7 +40,8 @@ func (c *calc) clear() {
 }
 
 func (c *calc) evaluate() {
-	if c.output.Text == "error" {
+	if strings.Contains(c.output.Text, "error") {
+		c.display("error")
 		return
 	}
 

--- a/calc.go
+++ b/calc.go
@@ -39,18 +39,30 @@ func (c *calc) clear() {
 }
 
 func (c *calc) evaluate() {
-	expression, err := govaluate.NewEvaluableExpression(c.output.Text)
-	if err == nil {
-		result, err := expression.Evaluate(nil)
-		if err == nil {
-			c.display(strconv.FormatFloat(result.(float64), 'f', -1, 64))
-		}
+	if c.output.Text == "error" {
+		return
 	}
 
+	expression, err := govaluate.NewEvaluableExpression(c.output.Text)
 	if err != nil {
 		log.Println("Error in calculation", err)
 		c.display("error")
+		return
 	}
+
+	result, err := expression.Evaluate(nil)
+	value, ok := result.(float64)
+	if err != nil {
+		log.Println("Error in calculation", err)
+		c.display("error")
+		return
+	} else if !ok {
+		log.Println("Invalid input:", c.output.Text)
+		c.display("error")
+		return
+	}
+
+	c.display(strconv.FormatFloat(value, 'f', -1, 64))
 }
 
 func (c *calc) addButton(text string, action func()) *widget.Button {

--- a/calc_test.go
+++ b/calc_test.go
@@ -153,6 +153,16 @@ func TestError(t *testing.T) {
 
 	test.TypeOnCanvas(calc.window.Canvas(), "1//1=")
 	assert.Equal(t, "error", calc.output.Text)
+
+	test.TypeOnCanvas(calc.window.Canvas(), "c")
+
+	test.TypeOnCanvas(calc.window.Canvas(), "()9=")
+	assert.Equal(t, "error", calc.output.Text)
+
+	test.TypeOnCanvas(calc.window.Canvas(), "c")
+
+	test.TypeOnCanvas(calc.window.Canvas(), "error=")
+	assert.Equal(t, "error", calc.output.Text)
 }
 
 func TestShortcuts(t *testing.T) {

--- a/calc_test.go
+++ b/calc_test.go
@@ -161,6 +161,9 @@ func TestError(t *testing.T) {
 
 	test.TypeOnCanvas(calc.window.Canvas(), "=")
 	assert.Equal(t, "error", calc.output.Text)
+
+	test.TypeOnCanvas(calc.window.Canvas(), "55=")
+	assert.Equal(t, "error", calc.output.Text)
 }
 
 func TestShortcuts(t *testing.T) {

--- a/calc_test.go
+++ b/calc_test.go
@@ -159,9 +159,7 @@ func TestError(t *testing.T) {
 	test.TypeOnCanvas(calc.window.Canvas(), "()9=")
 	assert.Equal(t, "error", calc.output.Text)
 
-	test.TypeOnCanvas(calc.window.Canvas(), "c")
-
-	test.TypeOnCanvas(calc.window.Canvas(), "error=")
+	test.TypeOnCanvas(calc.window.Canvas(), "=")
 	assert.Equal(t, "error", calc.output.Text)
 }
 


### PR DESCRIPTION
This works around some issues inside govaluate that caused the application to crash.
As it turns out, it can sometimes return a nil value without actually returning an error. In the process of testing my fix, I also noticed that trying to parse "error" makes govaluate crash (even though it ideally should return an error).

Fixes #16